### PR TITLE
Fix endpoint types for consistency with the Logz API

### DIFF
--- a/endpoints/client_endpoints_create.go
+++ b/endpoints/client_endpoints_create.go
@@ -4,19 +4,18 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/jonboydell/logzio_client"
 	"net/http"
 	"strings"
+
+	"github.com/jonboydell/logzio_client"
 )
 
 const (
 	createEndpointServiceUrl    string = endpointServiceEndpoint + "/%s"
 	createEndpointServiceMethod string = http.MethodPost
-	createEndpointMethodSuccess int    = 200
 )
 
 const (
-	errorInvalidEndpointDefinition   = "endpoint definition %v is not valid for service %s"
 	errorCreateEndpointApiCallFailed = "API call CreateEndpoint failed with status code %d, data: %s"
 )
 
@@ -65,7 +64,7 @@ func buildCreateEndpointRequest(endpoint Endpoint) map[string]interface{} {
 	return createEndpoint
 }
 
-func (c *EndpointsClient) buildCreateEndpointApiRequest(apiToken string, service string, endpoint Endpoint) (*http.Request, error) {
+func (c *EndpointsClient) buildCreateEndpointApiRequest(apiToken string, endpointType endpointType, endpoint Endpoint) (*http.Request, error) {
 	createEndpoint := buildCreateEndpointRequest(endpoint)
 
 	jsonBytes, err := json.Marshal(createEndpoint)
@@ -74,7 +73,7 @@ func (c *EndpointsClient) buildCreateEndpointApiRequest(apiToken string, service
 	}
 
 	baseUrl := c.BaseUrl
-	url := fmt.Sprintf(createEndpointServiceUrl, baseUrl, service)
+	url := fmt.Sprintf(createEndpointServiceUrl, baseUrl, c.getURLByType(endpointType))
 	req, err := http.NewRequest(createEndpointServiceMethod, url, bytes.NewBuffer(jsonBytes))
 	logzio_client.AddHttpHeaders(apiToken, req)
 

--- a/endpoints/client_endpoints_delete.go
+++ b/endpoints/client_endpoints_delete.go
@@ -2,9 +2,10 @@ package endpoints
 
 import (
 	"fmt"
-	"github.com/jonboydell/logzio_client"
 	"net/http"
 	"strings"
+
+	"github.com/jonboydell/logzio_client"
 )
 
 const (
@@ -17,11 +18,11 @@ const (
 	errorDeleteEndpointDoesntExist = "API call DeleteEndpoint failed as endpoint with id:%d doesn't exist, data:%s"
 )
 
-func validateDeleteEndpoint(endpoint Endpoint) (error, bool) {
-	return nil, true
+func validateDeleteEndpoint(endpoint Endpoint) bool {
+	return true
 }
 
-func (c *EndpointsClient) buildDeleteEndpointApiRequest(apiToken string, service string, endpoint Endpoint) (*http.Request, error) {
+func (c *EndpointsClient) buildDeleteEndpointApiRequest(apiToken string, service endpointType, endpoint Endpoint) (*http.Request, error) {
 	baseUrl := c.BaseUrl
 	req, err := http.NewRequest(deleteEndpointServiceMethod, fmt.Sprintf(deleteEndpointServiceUrl, baseUrl, endpoint.Id), nil)
 	logzio_client.AddHttpHeaders(apiToken, req)

--- a/endpoints/client_endpoints_validate.go
+++ b/endpoints/client_endpoints_validate.go
@@ -1,10 +1,5 @@
 package endpoints
 
-import (
-	"fmt"
-	"strings"
-)
-
 func validSlackEndpoint(endpointType Endpoint) bool {
 	return len(endpointType.Title) > 0 &&
 		len(endpointType.Url) > 0 && len(endpointType.Description) > 0
@@ -40,31 +35,23 @@ func validVictorOpsEndpoint(endpointType Endpoint) bool {
 		len(endpointType.RoutingKey) > 0 && len(endpointType.MessageType) > 0 && len(endpointType.ServiceApiKey) > 0
 }
 
-// Validates an endpoint request for correctness given it's type, returns an error and FALSE if validation is failed, true otherwise
-func ValidateEndpointRequest(endpoint Endpoint) (error, bool) {
-	if strings.EqualFold(EndpointTypeSlack, endpoint.EndpointType) && validSlackEndpoint(endpoint) {
-		return nil, true
+// ValidateEndpointRequest validates an endpoint request for correctness given its type,
+// returns FALSE if validation failed, true otherwise
+func ValidateEndpointRequest(endpoint Endpoint) bool {
+	switch endpoint.EndpointType {
+	case EndpointTypeSlack:
+		return validSlackEndpoint(endpoint)
+	case EndpointTypeCustom:
+		return validCustomEndpoint(endpoint)
+	case EndpointTypePagerDuty:
+		return validPagerDutyEndpoint(endpoint)
+	case EndpointTypeBigPanda:
+		return validBigPandaEndpoint(endpoint)
+	case EndpointTypeDataDog:
+		return validDataDogEndpoint(endpoint)
+	case EndpointTypeVictorOps:
+		return validVictorOpsEndpoint(endpoint)
+	default:
+		return false
 	}
-
-	if strings.EqualFold(EndpointTypeCustom, endpoint.EndpointType) && validCustomEndpoint(endpoint) {
-		return nil, true
-	}
-
-	if strings.EqualFold(EndpointTypePagerDuty, endpoint.EndpointType) && validPagerDutyEndpoint(endpoint) {
-		return nil, true
-	}
-
-	if strings.EqualFold(EndpointTypeBigPanda, endpoint.EndpointType) && validBigPandaEndpoint(endpoint) {
-		return nil, true
-	}
-
-	if strings.EqualFold(EndpointTypeDataDog, endpoint.EndpointType) && validDataDogEndpoint(endpoint) {
-		return nil, true
-	}
-
-	if strings.EqualFold(EndpointTypeVictorOps, endpoint.EndpointType) && validVictorOpsEndpoint(endpoint) {
-		return nil, true
-	}
-
-	return fmt.Errorf(errorInvalidEndpointDefinition, endpoint, endpoint.EndpointType), false
 }

--- a/endpoints/endpoints_create_bigpanda_test.go
+++ b/endpoints/endpoints_create_bigpanda_test.go
@@ -3,11 +3,12 @@ package endpoints_test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/jonboydell/logzio_client/endpoints"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/jonboydell/logzio_client/endpoints"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEndpoints_CreateBigPandaEndpoint(t *testing.T) {

--- a/endpoints/validation_endpoints_integration_test.go
+++ b/endpoints/validation_endpoints_integration_test.go
@@ -1,36 +1,33 @@
 package endpoints_test
 
 import (
+	"testing"
+
 	"github.com/jonboydell/logzio_client/endpoints"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestEndpoints_InvalidEndpoint(t *testing.T) {
-	if err, ok := endpoints.ValidateEndpointRequest(endpoints.Endpoint{
+	if endpoints.ValidateEndpointRequest(endpoints.Endpoint{
 		Title: "title",
-	}); ok {
+	}) {
 		assert.Fail(t, "shouldn't be true")
-	} else {
-		assert.Error(t, err)
 	}
 }
 
 func TestEndpoints_ValidateSlackEndpoint(t *testing.T) {
-	if err, ok := endpoints.ValidateEndpointRequest(endpoints.Endpoint{
+	if !endpoints.ValidateEndpointRequest(endpoints.Endpoint{
 		Title:        "title",
 		Description:  "description",
 		Url:          "url",
 		EndpointType: endpoints.EndpointTypeSlack,
-	}); ok {
-		assert.NoError(t, err)
-	} else {
+	}) {
 		assert.Fail(t, "shouldn't be false")
 	}
 }
 
 func TestEndpoints_ValidateCustomEndpoint(t *testing.T) {
-	if err, ok := endpoints.ValidateEndpointRequest(endpoints.Endpoint{
+	if !endpoints.ValidateEndpointRequest(endpoints.Endpoint{
 		Title:        "title",
 		Description:  "description",
 		Url:          "url",
@@ -38,64 +35,54 @@ func TestEndpoints_ValidateCustomEndpoint(t *testing.T) {
 		Headers:      map[string]string{"key": "value"},
 		BodyTemplate: "{\"hello\":\"there\"}",
 		EndpointType: endpoints.EndpointTypeCustom,
-	}); ok {
-		assert.NoError(t, err)
-	} else {
+	}) {
 		assert.Fail(t, "shouldn't be false")
 	}
 }
 
 func TestEndpoints_ValidatePagerDuty(t *testing.T) {
-	if err, ok := endpoints.ValidateEndpointRequest(endpoints.Endpoint{
+	if !endpoints.ValidateEndpointRequest(endpoints.Endpoint{
 		Title:        "title",
 		Description:  "description",
 		ServiceKey:   "serviceKey",
 		EndpointType: endpoints.EndpointTypePagerDuty,
-	}); ok {
-		assert.NoError(t, err)
-	} else {
+	}) {
 		assert.Fail(t, "shouldn't be false")
 	}
 }
 
 func TestEndpointsValidateBigPanda(t *testing.T) {
-	if err, ok := endpoints.ValidateEndpointRequest(endpoints.Endpoint{
+	if !endpoints.ValidateEndpointRequest(endpoints.Endpoint{
 		Title:        "title",
 		Description:  "description",
 		ApiToken:     "ApiToken",
 		AppKey:       "AppKey",
 		EndpointType: endpoints.EndpointTypeBigPanda,
-	}); ok {
-		assert.NoError(t, err)
-	} else {
+	}) {
 		assert.Fail(t, "shouldn't be false")
 	}
 }
 
 func TestEndpointsValidateDataDog(t *testing.T) {
-	if err, ok := endpoints.ValidateEndpointRequest(endpoints.Endpoint{
+	if !endpoints.ValidateEndpointRequest(endpoints.Endpoint{
 		Title:        "title",
 		Description:  "description",
 		ApiKey:       "ApiKey",
 		EndpointType: endpoints.EndpointTypeDataDog,
-	}); ok {
-		assert.NoError(t, err)
-	} else {
+	}) {
 		assert.Fail(t, "shouldn't be false")
 	}
 }
 
 func TestEndpointsValidateVictorOps(t *testing.T) {
-	if err, ok := endpoints.ValidateEndpointRequest(endpoints.Endpoint{
+	if !endpoints.ValidateEndpointRequest(endpoints.Endpoint{
 		Title:         "title",
 		Description:   "description",
 		RoutingKey:    "routingKey",
 		MessageType:   "messageType",
 		ServiceApiKey: "serviceApiKey",
 		EndpointType:  endpoints.EndpointTypeVictorOps,
-	}); ok {
-		assert.NoError(t, err)
-	} else {
+	}) {
 		assert.Fail(t, "shouldn't be false")
 	}
 }


### PR DESCRIPTION
Previously, the endpoint type values were not matching what was returned
from the Logz.io API. This made the consumers of the package to manage
their own constants when using the endpoint types. This commit fixes
that by using the same values returned from the Logz API as the constant
for endpoint type. It also adds a helper function to get the URL for
each endpoint type.